### PR TITLE
ember-power-selected selected option test

### DIFF
--- a/tests/integration/components/bs-form/element/control/power-select-test.js
+++ b/tests/integration/components/bs-form/element/control/power-select-test.js
@@ -126,3 +126,13 @@ test('it passes power-select options', async function(assert) {
   await clickTrigger();
   assert.notOk(find('.ember-power-select-search-input'));
 });
+
+test('it passes selected option', async function(assert) {
+  this.set('options', this.get('options'));
+  this.set('selected', this.get('options')[0]);
+  this.render(hbs`
+  {{#bs-form model=this as |form|}}
+    {{form.element controlType="power-select" options=options selected=selected}}
+  {{/bs-form}}`);
+  assert.equal(find('.ember-power-select-selected-item').textContent.trim(), 'foo');
+});


### PR DESCRIPTION
- The documentation [says](https://github.com/MichalBryxi/ember-bootstrap-power-select#advanced-usage):

>The power-select's selected, disabled and placeholder properties and the onchange action are already wired up to the controlling form.element for you

I tried, it did not work. So I tried to poke deeper and found these:
 - https://github.com/kaliber5/ember-bootstrap-power-select/blob/6566374b18ce372a255b87f2fac76cebc28f0f06/addon/templates/components/bs-form/element/control/power-select.hbs#L4
 - https://github.com/kaliber5/ember-bootstrap-power-select/blob/6566374b18ce372a255b87f2fac76cebc28f0f06/addon/templates/components/bs-form/element/control/power-select.hbs#L31

So I tried to alter my code to pass `value` property and it worked:

```
{{#bs-form model=this as |form|}}
    {{form.element controlType="power-select" options=options value=selected}}
  {{/bs-form}}
```

So I'm proposing this failing test to alter the behaviour to be in line with official [ember-power-select docs](http://www.ember-power-select.com/docs/api-reference). And I think that property should be changed to from `value` to `selected`.