### PR TITLE
feat: allow overriding the power select components used in the templates when extending

### DIFF
--- a/addon/components/bs-form/element/control/power-select-multiple.js
+++ b/addon/components/bs-form/element/control/power-select-multiple.js
@@ -3,5 +3,17 @@ import layout from '../../../../templates/components/bs-form/element/control/pow
 
 export default Control.extend({
   layout,
-  tagName: ''
+  tagName: '',
+
+  /**
+   * @property powerSelectComponent
+   * @type {String}
+   */
+  powerSelectComponent: 'power-select-multiple',
+
+  /**
+   * @property powerSelectBlocklessComponent
+   * @type {String}
+   */
+  powerSelectBlocklessComponent: 'power-select-blockless'
 });

--- a/addon/components/bs-form/element/control/power-select-multiple.js
+++ b/addon/components/bs-form/element/control/power-select-multiple.js
@@ -15,5 +15,5 @@ export default Control.extend({
    * @property powerSelectBlocklessComponent
    * @type {String}
    */
-  powerSelectBlocklessComponent: 'power-select-blockless'
+  powerSelectBlocklessComponent: 'power-select-multiple-blockless'
 });

--- a/addon/components/bs-form/element/control/power-select.js
+++ b/addon/components/bs-form/element/control/power-select.js
@@ -3,5 +3,17 @@ import layout from '../../../../templates/components/bs-form/element/control/pow
 
 export default Control.extend({
   layout,
-  tagName: ''
+  tagName: '',
+
+  /**
+   * @property powerSelectComponent
+   * @type {String}
+   */
+  powerSelectComponent: 'power-select',
+
+  /**
+   * @property powerSelectBlocklessComponent
+   * @type {String}
+   */
+  powerSelectBlocklessComponent: 'power-select-blockless'
 });

--- a/addon/templates/components/bs-form/element/control/power-select-multiple.hbs
+++ b/addon/templates/components/bs-form/element/control/power-select-multiple.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  {{#power-select-multiple
+  {{#component powerSelectComponent
     afterOptionsComponent=afterOptionsComponent
     allowClear=allowClear
     ariaDescribedBy=ariaDescribedBy
@@ -54,9 +54,9 @@
     as |item select|
   }}
     {{yield item select}}
-  {{/power-select-multiple}}
+  {{/component}}
 {{else}}
-  {{power-select-multiple-blockless
+  {{component powerSelectBlocklessComponent
     afterOptionsComponent=afterOptionsComponent
     allowClear=allowClear
     ariaDescribedBy=ariaDescribedBy

--- a/addon/templates/components/bs-form/element/control/power-select.hbs
+++ b/addon/templates/components/bs-form/element/control/power-select.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  {{#power-select
+  {{#component powerSelectComponent
     afterOptionsComponent=afterOptionsComponent
     allowClear=allowClear
     ariaDescribedBy=ariaDescribedBy
@@ -54,9 +54,9 @@
     as |item select|
   }}
     {{yield item select}}
-  {{/power-select}}
+  {{/component}}
 {{else}}
-  {{power-select-blockless
+  {{component powerSelectBlocklessComponent
     afterOptionsComponent=afterOptionsComponent
     allowClear=allowClear
     ariaDescribedBy=ariaDescribedBy


### PR DESCRIPTION
Similar in scope to https://github.com/kaliber5/ember-bootstrap/pull/685

Basically allows overriding which `power-select` components  the `ember-bootstrap-power-select` uses when extending `ember-bootstrap-power-select` compoennts.

This is useful when using some custom extended `power-select` components - for example if there's some internal `my-power-select` variant in the consuming app which we'd like to be used in `ember-bootstrap`.