### PR TITLE
Add @placeholder attribute

### DIFF
--- a/addon/components/bs-form/element/control/power-select.hbs
+++ b/addon/components/bs-form/element/control/power-select.hbs
@@ -35,6 +35,7 @@
     @onOpen={{@onOpen}}
     @options={{@options}}
     @optionsComponent={{@optionsComponent}}
+    @placeholder={{@placeholder}}
     @placeholderComponent={{@placeholderComponent}}
     @preventScroll={{@preventScroll}}
     @registerAPI={{@registerAPI}}


### PR DESCRIPTION
There are instances of `@placeholder` applied to `<form.element>` (e. g. [here](https://github.com/kaliber5/ember-bootstrap-power-select/blob/ca196339a86f1582c99cd6aa6b0cc898331dd29f/tests/dummy/app/templates/application.hbs#L8) and [here](https://github.com/kaliber5/ember-bootstrap-power-select/blob/ca196339a86f1582c99cd6aa6b0cc898331dd29f/tests/integration/components/bs-form/element/control/power-select-test.js#L104)) but I think they are erroneous. The dummy app is not rendering any placeholders.