### PR TITLE
drop support for node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
       - name: Lint
@@ -40,7 +40,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
       - name: Test

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compatibility
 * Ember Bootstrap v4 or above
 * Ember.js v3.16 or above
 * Ember CLI v3.15 or above
-* Node.js v10 or above
+* Node.js v12 or above
 
 Installation
 ------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "release-it-lerna-changelog": "^3.1.0"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "12.* || >= 14.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Node 12 is also only supported until end of this month. So maybe we could drop support for that one as well in next major.