### PR TITLE
Placeholder argument for power-select-multiple control

### DIFF
--- a/addon/components/bs-form/element/control/power-select-multiple.hbs
+++ b/addon/components/bs-form/element/control/power-select-multiple.hbs
@@ -35,6 +35,7 @@
     @onOpen={{@onOpen}}
     @options={{@options}}
     @optionsComponent={{@optionsComponent}}
+    @placeholder={{@placeholder}}
     @placeholderComponent={{@placeholderComponent}}
     @preventScroll={{@preventScroll}}
     @registerAPI={{@registerAPI}}


### PR DESCRIPTION
Passing the placeholder argument from the power-select-multiple control to the ember power select.